### PR TITLE
Disallow incoming connections

### DIFF
--- a/cmd/debug/p2p/v2/main.go
+++ b/cmd/debug/p2p/v2/main.go
@@ -20,7 +20,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conf := p2p.Config{DummyConfigurationFeatureEnable: true}
+	conf := p2p.Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 
 	node, err := p2p.NewPeer(ctx, logger, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, p2p.PeerSecurityTLS)
 	if err != nil {

--- a/pkg/p2p/v2/message_protocol_test.go
+++ b/pkg/p2p/v2/message_protocol_test.go
@@ -58,7 +58,7 @@ func (s testStream) Conn() network.Conn {
 
 func TestMessageProtocol_NewMessageProtocol(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 	p, _ := NewPeer(context.Background(), logger, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 
 	mp := NewMessageProtocol(context.Background(), logger, p)
@@ -81,7 +81,7 @@ func TestMessageProtocol_OnRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := log.NewDefaultProductionLogger()
 			loggerTest := testLogger{Logger: logger}
-			conf := Config{DummyConfigurationFeatureEnable: true}
+			conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 			p, _ := NewPeer(context.Background(), &loggerTest, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 			mp := NewMessageProtocol(context.Background(), &loggerTest, p)
 
@@ -103,7 +103,7 @@ func TestMessageProtocol_OnRequest(t *testing.T) {
 func TestMessageProtocol_OnResponse(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
 	loggerTest := testLogger{Logger: logger}
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 	p, _ := NewPeer(context.Background(), &loggerTest, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 	mp := NewMessageProtocol(context.Background(), &loggerTest, p)
 	ch := make(chan *ResponseMsg, 1)
@@ -133,7 +133,7 @@ func TestMessageProtocol_OnResponse(t *testing.T) {
 func TestMessageProtocol_OnResponseUnknownRequestID(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
 	loggerTest := testLogger{Logger: logger}
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 	p, _ := NewPeer(context.Background(), &loggerTest, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 	mp := NewMessageProtocol(context.Background(), &loggerTest, p)
 	// There is no channel for the request ID "123456"
@@ -150,7 +150,7 @@ func TestMessageProtocol_OnResponseUnknownRequestID(t *testing.T) {
 
 func TestMessageProtocol_SendRequestMessage(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 
 	p1, _ := NewPeer(context.Background(), logger, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 	mp1 := NewMessageProtocol(context.Background(), logger, p1)
@@ -170,7 +170,7 @@ func TestMessageProtocol_SendRequestMessage(t *testing.T) {
 
 func TestMessageProtocol_SendRequestMessageTimeout(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 
 	p1, _ := NewPeer(context.Background(), logger, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 	mp1 := NewMessageProtocol(context.Background(), logger, p1)
@@ -192,7 +192,7 @@ func TestMessageProtocol_SendRequestMessageTimeout(t *testing.T) {
 
 func TestMessageProtocol_SendResponseMessage(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 
 	p1, _ := NewPeer(context.Background(), logger, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)
 	mp1 := NewMessageProtocol(context.Background(), logger, p1)
@@ -233,7 +233,7 @@ func (tmr *TestMessageReceive) onMessageReceive(s network.Stream) {
 
 func TestMessageProtocol_SendProtoMessage(t *testing.T) {
 	logger, _ := log.NewDefaultProductionLogger()
-	conf := Config{DummyConfigurationFeatureEnable: true}
+	conf := Config{DummyConfigurationFeatureEnable: true, AllowIncomingConnections: true}
 	tmr := TestMessageReceive{done: make(chan any)}
 
 	p1, _ := NewPeer(context.Background(), logger, conf, []string{"/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"}, PeerSecurityTLS)

--- a/pkg/p2p/v2/p2p.go
+++ b/pkg/p2p/v2/p2p.go
@@ -17,6 +17,7 @@ const stopTimeout = time.Second * 5 // P2P service stop timeout in seconds.
 // TODO - get configuration from config file (GH issue #14)
 type Config struct {
 	DummyConfigurationFeatureEnable bool
+	AllowIncomingConnections        bool
 }
 
 // P2P type - a p2p service.
@@ -32,7 +33,10 @@ type P2P struct {
 // NewP2P creates a new P2P instance.
 func NewP2P() *P2P {
 	// TODO - get configuration from config file (GH issue #14)
-	return &P2P{conf: Config{DummyConfigurationFeatureEnable: true}}
+	return &P2P{conf: Config{
+		DummyConfigurationFeatureEnable: true,
+		AllowIncomingConnections:        true,
+	}}
 }
 
 // Start function starts a P2P and all other related services.

--- a/pkg/p2p/v2/peer.go
+++ b/pkg/p2p/v2/peer.go
@@ -68,10 +68,15 @@ func NewPeer(ctx context.Context, logger log.Logger, conf Config, addrs []string
 		libp2p.DefaultTransports,
 	}
 
-	if len(addrs) == 0 {
+	switch conf.AllowIncomingConnections {
+	case true:
+		if len(addrs) == 0 {
+			opts = append(opts, libp2p.NoListenAddrs)
+		} else {
+			opts = append(opts, libp2p.ListenAddrStrings(addrs...))
+		}
+	case false:
 		opts = append(opts, libp2p.NoListenAddrs)
-	} else {
-		opts = append(opts, libp2p.ListenAddrStrings(addrs...))
 	}
 
 	switch security {
@@ -127,6 +132,11 @@ func (p *Peer) Close() error {
 // Connect to a peer.
 func (p *Peer) Connect(ctx context.Context, peer peer.AddrInfo) error {
 	return p.host.Connect(ctx, peer)
+}
+
+// Disconnect from a peer.
+func (p *Peer) Disconnect(ctx context.Context, peer peer.ID) error {
+	return p.host.Network().ClosePeer(peer)
 }
 
 // ID returns a peers's identifier.


### PR DESCRIPTION
### What was the problem?

- This PR resolves #9.

### How was it solved?

- If `AllowIncomingConnections` is set to `false`, peer has no listen addresses.

### How was it tested?

- New unit tests were implemented.
- Existing and new unit tests passed.
