### PR TITLE
Author of a published message is hidden

### DIFF
--- a/pkg/p2p/v2/gossipsub.go
+++ b/pkg/p2p/v2/gossipsub.go
@@ -144,6 +144,9 @@ func (gs *GossipSub) Start(ctx context.Context,
 				pubsub.NewAllowlistSubscriptionFilter(topics...),
 				maxAllowedTopics)))
 
+	// We want to hide the author of the message from the topic subscribers.
+	options = append(options, pubsub.WithNoAuthor())
+
 	gossipSub, err := pubsub.NewGossipSub(ctx, p.GetHost(), options...)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What was the problem?

This PR resolves #15.

### How was it solved?

An option to omit author of a message was added to a `gossipsub` configuration options.

### How was it tested?

All unit tests passed.
