### PR TITLE
Fix invalid range check in readUint

### DIFF
--- a/pkg/codec/reader.go
+++ b/pkg/codec/reader.go
@@ -430,7 +430,7 @@ func readUint(data []byte, offset int) (uint64, int, error) {
 		}
 		bit := uint64(data[index])
 		index++
-		if index == 10+index && bit > 0x01 {
+		if index == offset+10 && bit > 0x01 {
 			return 0, 0, ErrOutOfRange
 		}
 		result |= (bit & uint64(rest8Bit)) << shift

--- a/pkg/codec/reader_test.go
+++ b/pkg/codec/reader_test.go
@@ -136,6 +136,13 @@ func TestReadUInt(t *testing.T) {
 			result:      372036854775807,
 		},
 		{
+			input:       "08ffffffffffffffffff02", // invalid range
+			fieldNumber: 1,
+			strict:      false,
+			result:      0,
+			err:         "out of range",
+		},
+		{
 			input:       "08ffffc9a4d9cb54",
 			fieldNumber: 2,
 			strict:      true,
@@ -199,6 +206,13 @@ func TestReadInt(t *testing.T) {
 			err:         "",
 		},
 		{
+			input:       "08ffffffffffffffffff02", // invalid range
+			fieldNumber: 1,
+			strict:      false,
+			result:      0,
+			err:         "out of range",
+		},
+		{
 			input:       "08fdffffffffffff1f",
 			fieldNumber: 2,
 			result:      -9007199254740991,
@@ -242,6 +256,13 @@ func TestReadInt32(t *testing.T) {
 			result:      -9007199254740991,
 			strict:      false,
 			err:         "",
+		},
+		{
+			input:       "08ffffffffffffffffff02", // invalid range
+			fieldNumber: 1,
+			strict:      false,
+			result:      0,
+			err:         "out of range",
 		},
 		{
 			input:       "08fdffffffffffff1f",


### PR DESCRIPTION
### What was the problem?

This PR resolves #86.

### How was it solved?

Check for `uint64` number range was fixed.

### How was it tested?

- Some existing unit tests were modified to test range when calling `readUint` function.
- All modified and existing unit tests passed.